### PR TITLE
게시글 삭제 및 첨부파일 표시 기능 개선

### DIFF
--- a/src/api/PostApi.js
+++ b/src/api/PostApi.js
@@ -22,7 +22,7 @@ export const postAPI = {
 
     // 게시글 상세 조회
     getPostDetail: async (postId) => {
-        const response = await api.get(`/${postId}`, {withCredentials: true});
+        const response = await api.get(`/${postId}`, { withCredentials: true });
         return response.data.data;
     },
 
@@ -38,7 +38,7 @@ export const postAPI = {
     },
 
     // 게시글 등록
-    createPost: async (postData) => {
+    create: async (postData) => {
         const response = await api.post('', postData, {
             headers: {
                 'Content-Type': 'multipart/form-data',
@@ -46,5 +46,11 @@ export const postAPI = {
         });
 
         return response.data.data;
-    }
+    },
+
+    // 게시글 삭제
+    delete: async (postId) => {
+        const response = await api.delete(`/${postId}`);
+        return response.data.data;
+    },
 };

--- a/src/components/community/PostDetail.jsx
+++ b/src/components/community/PostDetail.jsx
@@ -91,15 +91,23 @@ const PostStats = styled.div`
 `;
 
 const AttachmentSection = styled.div`
-  padding-bottom: 15px;
+  padding-bottom: 10px;
   margin-bottom: 30px;
-  font-size: 15px;
   border-bottom: 1px solid #eee;
+  display: flex;
 `;
+
+const AttachmentLabel = styled.div`
+  font-weight: bold;
+  color: ${({ theme }) => theme.colors.dark};
+  margin-right: 15px;
+  font-size: 13px;
+`
 
 const AttachmentList = styled.ul`
   color: #444;
   display: flex;
+  font-size: 12px;
 `;
 
 const AttachmentItem = styled.li`
@@ -114,6 +122,12 @@ const AttachmentItem = styled.li`
 const AttachmentLink = styled.a`
   color: ${({ theme }) => theme.colors.dark};
   text-decoration: none;
+  max-width: 175px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  vertical-align: bottom;
 
   &:hover {
   color: ${({ theme }) => theme.colors.secondary};
@@ -122,8 +136,8 @@ const AttachmentLink = styled.a`
 
 const AttachmentSize = styled.span`
   color: ${({ theme }) => theme.colors.dark};
-  margin-left: 3px;
-  font-size: 12px;
+  margin-left: 1px;
+  font-size: 11px;
 `;
 
 const Content = styled.div`
@@ -433,6 +447,8 @@ const PostDetail = () => {
 
   const { id } = useParams();
   const [post, setPost] = useState(null);
+  const userId = localStorage.getItem("userId");
+  const isAuthor = post && post.authorId === userId;
 
   useEffect(() => {
     const fetchPostDetail = async () => {
@@ -463,8 +479,12 @@ const PostDetail = () => {
           )}
         </Info>
         <Actions>
-          <ActionButton><FaPencilAlt /> 수정</ActionButton>
-          <ActionButton><FaTrash /> 삭제</ActionButton>
+          {isAuthor && (
+            <>
+            <ActionButton><FaPencilAlt /> 수정</ActionButton>
+            <ActionButton><FaTrash /> 삭제</ActionButton>
+            </>
+          )}
           <PostStats><FaEye />{post.views} </PostStats>
           <PostStats><FaCommentDots /> {post.commentCount}</PostStats>
         </Actions>
@@ -472,10 +492,11 @@ const PostDetail = () => {
 
       {post.attachments && post.attachments.length > 0 && (
         <AttachmentSection>
+          <AttachmentLabel>첨부파일</AttachmentLabel>
           <AttachmentList>
             {post.attachments.map((file, idx) => (
               <AttachmentItem key={idx}>
-                <AttachmentLink href={file.url} download target="_blank" rel="noopener noreferrer">
+                <AttachmentLink href={file.url} download target="_blank" rel="noopener noreferrer" title={file.name}>
                   · {file.name}
                 </AttachmentLink>
                 <AttachmentSize>({formatFileSize(file.size)})</AttachmentSize>

--- a/src/components/community/PostDetail.jsx
+++ b/src/components/community/PostDetail.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from "react-router-dom";
 import styled from 'styled-components';
-import { FaPencilAlt, FaTrash, FaArrowUp, FaArrowDown, FaFlag, FaReply, FaPen, FaHome, FaList, FaEye } from 'react-icons/fa';
+import { FaPencilAlt, FaTrash, FaArrowUp, FaArrowDown, FaFlag, FaReply, FaPen, FaHome, FaList, FaEye, FaCommentDots } from 'react-icons/fa';
 import { postAPI } from '../../api/PostApi';
 import { format, parseISO } from 'date-fns';
 
@@ -52,7 +52,8 @@ const Info = styled.div`
 
 const Actions = styled.div`
   display: flex;
-  gap: 10px;
+  gap: 15px;
+  padding-right: 5px;
 `;
 
 const ActionButton = styled.button`
@@ -63,7 +64,7 @@ const ActionButton = styled.button`
   font-size: 14px;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
   &:hover {
     color: #4d82f3;
   }
@@ -75,7 +76,7 @@ const ActionButton = styled.button`
   }
 `;
 
-const ViewCount = styled.div`
+const PostStats = styled.div`
   display: flex;
   align-items: center;
   font-size: 14px;
@@ -464,7 +465,8 @@ const PostDetail = () => {
         <Actions>
           <ActionButton><FaPencilAlt /> 수정</ActionButton>
           <ActionButton><FaTrash /> 삭제</ActionButton>
-          <ViewCount><FaEye />{post.views}</ViewCount>
+          <PostStats><FaEye />{post.views} </PostStats>
+          <PostStats><FaCommentDots /> {post.commentCount}</PostStats>
         </Actions>
       </Meta>
 

--- a/src/components/community/PostDetail.jsx
+++ b/src/components/community/PostDetail.jsx
@@ -450,6 +450,20 @@ const PostDetail = () => {
   const userId = localStorage.getItem("userId");
   const isAuthor = post && post.authorId === userId;
 
+  // 게시글 삭제 핸들러
+  const handleDelete = async () => {
+    if (!window.confirm("게시글을 삭제하시겠습니까?")) return;
+  
+    try {
+      await postAPI.delete(id);
+      navigate("/community");
+    } catch (error) {
+      console.error("게시글 삭제 실패:", error);
+      alert("삭제에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
+
+
   useEffect(() => {
     const fetchPostDetail = async () => {
       try {
@@ -482,7 +496,7 @@ const PostDetail = () => {
           {isAuthor && (
             <>
             <ActionButton><FaPencilAlt /> 수정</ActionButton>
-            <ActionButton><FaTrash /> 삭제</ActionButton>
+            <ActionButton onClick={handleDelete}><FaTrash /> 삭제</ActionButton>
             </>
           )}
           <PostStats><FaEye />{post.views} </PostStats>

--- a/src/components/community/PostEditor.jsx
+++ b/src/components/community/PostEditor.jsx
@@ -603,17 +603,25 @@ const PostEditor = () => {
                             disabled={selectedFiles.length >= 5}
                             onChange={(e) => {
                                 const maxSize = Number(process.env.REACT_APP_MAX_FILE_SIZE_MB || 10) * 1024 * 1024;
+                                const maxNameLength = 50;
+
                                 const files = Array.from(e.target.files || []);
-                                const validFiles = files.filter(file => file.size <= maxSize);
+                                const tooLong = files.filter(file => file.name.length > maxNameLength);
+                                const validFiles = files.filter(file => file.name.length <= maxNameLength && file.size <= maxSize);
 
                                 const combined = [...selectedFiles, ...validFiles].slice(0, 5); // 최대 5개 제한
 
                                 setSelectedFiles(combined);
+                                   
+                                if (tooLong.length > 0) {
+                                    alert(`파일 이름은 최대 ${maxNameLength}자까지만 가능합니다.`);
+                                }
 
                                 const rejected = files.filter(file => file.size > maxSize);
                                 if (rejected.length > 0) {
                                     alert(`파일 크기는 최대 ${process.env.REACT_APP_MAX_FILE_SIZE_MB || 10}MB까지만 업로드할 수 있습니다.`);
                                 }
+
                                 e.target.value = "";
                             }}
                         />

--- a/src/components/community/PostEditor.jsx
+++ b/src/components/community/PostEditor.jsx
@@ -549,7 +549,7 @@ const PostEditor = () => {
                 formDataObj.append("attachments", file);
             });
 
-            const postId = await postAPI.createPost(formDataObj);
+            const postId = await postAPI.create(formDataObj);
             
             navigate(`/community/post/${postId}`);
         } catch (err) {


### PR DESCRIPTION
## 게시글 삭제 및 첨부파일 표시 기능 개선

### 주요 변경 사항
- 게시글 삭제 기능 구현  
  - `postAPI`에 `delete` 메서드 추가  
  - `PostDetail.jsx`에서 삭제 버튼 클릭 시 삭제 요청 및 커뮤니티 메인으로 이동하도록 구현  
  - `PostController`, `PostService`에 삭제 처리 로직 반영 (soft delete)
- postAPI 메서드 네이밍 통일  
  - `createPost` → `create`로 변경  
  - `PostEditor` 호출부도 이에 맞춰 수정
- 첨부파일 이름 UI 처리 개선  
  - 첨부파일 이름이 너무 길 경우 `...`으로 표시되도록 처리  
  - 첨부파일 업로드 시 길이 제한 및 사용자 안내 로직 추가
- 권한 기반 UI 제어  
  - 로그인한 사용자와 게시글 작성자가 일치할 경우에만 수정/삭제 버튼 노출

### 변경 배경
- 게시글 삭제 기능이 누락되어 있어 기능 구현 필요  
- API 메서드 이름의 일관성을 위해 `createPost` → `create`로 리팩터링  
- 첨부파일 이름이 너무 길 경우 레이아웃이 깨지는 문제 개선  
- 사용자 권한에 따른 UI 조작 방지를 위해 조건부 렌더링 적용

### 테스트 방법
- 게시글 상세 페이지에서 삭제 버튼 클릭 시 정상적으로 삭제되고 커뮤니티 메인으로 이동되는지 확인  
- 첨부파일 이름이 긴 경우 UI에서 `...`으로 처리되는지 확인  
- 글 작성자 본인에게만 수정/삭제 버튼이 보이는지 확인  
- 게시글 작성 시 정상적으로 업로드 및 등록되는지 확인
