### PR TITLE
댓글 신고 모달 연동

### DIFF
--- a/src/components/community/comment/CommentItem.jsx
+++ b/src/components/community/comment/CommentItem.jsx
@@ -6,6 +6,7 @@ import { formatDateTime } from '../../../utils/DateFormatter';
 import { postCommentAPI } from '../../../api/PostCommentApi';
 import { communityVoteAPI } from '../../../api/CommunityVoteApi';
 import CommentForm from './CommentForm';
+import ReportModal from '../../report/ReportModal';
 
 // #region styled-components
 const Comment = styled.div`
@@ -121,6 +122,7 @@ const CommentItem = ({ comment, onDeleted, maxDepth = 4 }) => {
   const isAuthor = comment && comment.authorId === userId;
   const [showReplyForm, setShowReplyForm] = useState(false);
   const [showEditForm, setShowEditForm] = useState(false);
+  const [showReportModal, setShowReportModal] = useState(false);
   const [localComment, setLocalComment] = useState({ ...comment });
 
   const CommentItemWrapper = comment.depth === 0 ? Comment : Reply;
@@ -227,7 +229,14 @@ const CommentItem = ({ comment, onDeleted, maxDepth = 4 }) => {
               <ActionButton onClick={() => setShowReplyForm(prev => !prev)}><FaReply /> 답글</ActionButton>
             )}
             {!isAuthor && (
-              <ActionButton><FaFlag /> 신고</ActionButton>
+              <ActionButton onClick={() => setShowReportModal(true)}><FaFlag /> 신고</ActionButton>
+            )}
+            {showReportModal && (
+              <ReportModal
+                onClose={() => setShowReportModal(false)}
+                authorNickname={comment.authorNickname}
+                contentText={comment.content}
+              />
             )}
             {isAuthor && (
               <>


### PR DESCRIPTION
## 댓글 신고 모달 연동

### 주요 변경 사항
- CommentItem.jsx에서 댓글 신고 버튼 클릭 시 신고 모달 열리도록 처리  
- 게시글과 동일한 ReportModal.jsx를 활용하여 모달 재사용

### 변경 배경
- 댓글에 대해서도 신고 기능 필요
- 신고 모달 UI/UX 통일성 확보

### 테스트 방법
- 댓글 신고 버튼 클릭 시 모달이 정상적으로 열리는지 확인  
- 신고유형 선택 토글 동작 확인
